### PR TITLE
Encoding null attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.2.0
 
 - Support for Dart 3
+- Support for encoding `null` attributes
+- Prevent encoding from producing empty `relationships`
 
 ## 2.1.0
 

--- a/assets/encoding/encoding-1.json
+++ b/assets/encoding/encoding-1.json
@@ -2,6 +2,6 @@
   "type": "articles",
   "email": "user@example.com",
   "password": "password",
-  "push_token": "x",
+  "push_token": null,
   "uuid": "123"
 }

--- a/assets/result/encoding/result-encoding-1.json
+++ b/assets/result/encoding/result-encoding-1.json
@@ -4,9 +4,8 @@
     "attributes": {
       "email": "user@example.com",
       "password": "password",
-      "push_token": "x",
+      "push_token": null,
       "uuid": "123"
-    },
-    "relationships": {}
+    }
   }
 }

--- a/assets/result/encoding/result-encoding-6.json
+++ b/assets/result/encoding/result-encoding-6.json
@@ -8,7 +8,6 @@
         "Third Symptom",
         "Forth Symptom"
       ]
-    },
-    "relationships": {}
+    }
   }
 }

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:collection/collection.dart';
 
 class _TypeIdPair {
@@ -220,37 +221,33 @@ class Japx {
         final array = json[key] as List;
         final isArrayOfRelationships = array.first is Map<String, dynamic> &&
             _TypeIdPair.from(array.first) != null;
-        if (!isArrayOfRelationships) {
-          attributes[key] = array;
+        if (isArrayOfRelationships) {
+          final dataArray = array
+              .map((e) => _TypeIdPair.fromOrThrow(e))
+              .map((e) => e.toMap())
+              .toList();
+          relationships[key] = {_data: dataArray};
           json.remove(key);
           continue;
         }
-        final dataArray = array
-            .map((e) => _TypeIdPair.fromOrThrow(e))
-            .map((e) => e.toMap())
-            .toList();
-        relationships[key] = {_data: dataArray};
-        json.remove(key);
       }
       if (json[key] is Map<String, dynamic>) {
-        final map = json[key] as Map<String, dynamic>?;
+        final map = json[key] as Map<String, dynamic>;
         final typeIdPair = _TypeIdPair.from(map);
-        if (typeIdPair == null) {
-          attributes[key] = map;
+        if (typeIdPair != null) {
+          relationships[key] = {_data: typeIdPair.toMap()};
           json.remove(key);
           continue;
         }
-        relationships[key] = {_data: typeIdPair.toMap()};
-        json.remove(key);
-      }
-      if (json[key] == null) {
-        continue;
       }
       attributes[key] = json[key];
       json.remove(key);
     }
     json[_attributes] = attributes;
-    json[_relationships] = relationships;
+
+    if (relationships.isNotEmpty) {
+      json[_relationships] = relationships;
+    }
     return json;
   }
 


### PR DESCRIPTION
Added support for encoding `null` attributes (see `encoding-1` test).

Prevent encoding from producing `"relationships": {}`.
`"relationships": {}` is not a valid relationship object ([docs](https://jsonapi.org/format/#document-resource-object-relationships)), instead the resource object can omit the `relationship` member ([docs](https://jsonapi.org/format/#document-resource-objects)). So for resource objects without relationships lets not include the `relationship` member.